### PR TITLE
Update a data portal URL

### DIFF
--- a/src/tsdConsts.ts
+++ b/src/tsdConsts.ts
@@ -14,7 +14,7 @@ export namespace tsdConsts {
   );
   export const getUuidFromImportUrl = (s: string): UUID | undefined =>
     s.split("/").pop() as UUID;
-  export const tokenUrl = "https://data.tsd.usit.no/capability_token";
+  export const tokenUrl = "https://data.tsd.usit.no/v1/all/auth/instances/token";
   export const uploadUrl = ({
     project,
     group,


### PR DESCRIPTION
The `/capability_token` is basically an "alias" for the "fully-qualified" (by `/v1/` as prefix) URL that the upstream (from the data portal) API uses, denoting the same resource. Because the former "short" URL is only a convenience but comes at a cost of extra configuration for the data portal, ideally I would like to "deprecate" it in favour of the fully qualified URL. Another, related reason, to do away with the "short" URL is that we lack consistency over these vs. URLs that are defined by the API which are rightfully "owned" by it -- there isn't really any good reason to alias them in general, at least not for obtaining a capability token, since the API goes to some length by appropriately partitioning the hierarchical structure represented in the URL.